### PR TITLE
Add improved list toggling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[lib/**.js]
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/example/main.js
+++ b/example/main.js
@@ -51,6 +51,7 @@ class Example extends React.Component<*, *> {
 
     renderToolbar() {
         const {
+            toggleList,
             wrapInList,
             unwrapList,
             increaseItemDepth,
@@ -88,6 +89,10 @@ class Example extends React.Component<*, *> {
                 </button>
                 <button onClick={() => this.call(unwrapList)}>
                     Unwrap from list
+                </button>
+
+                <button onClick={() => this.call(toggleList)}>
+                    Toggle list
                 </button>
             </div>
         );

--- a/example/value.js
+++ b/example/value.js
@@ -17,52 +17,52 @@ export default (
         <document>
             <ul_list>
                 <list_item>
-                    <paragraph>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</paragraph>
+                    <paragraph>9 Lorem ipsum dolor sit amet, consectetur adipiscing elit.</paragraph>
                 </list_item>
                 <list_item>
-                    <paragraph>Nulla a risus mauris.</paragraph>
+                    <paragraph>10 Nulla a risus mauris.</paragraph>
                     <ul_list>
                         <list_item>
-                            <paragraph>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</paragraph>
+                            <paragraph>4 Lorem ipsum dolor sit amet, consectetur adipiscing elit.</paragraph>
                         </list_item>
                         <list_item>
-                            <paragraph>Nulla a risus mauris.</paragraph>
+                            <paragraph>5 Nulla a risus mauris.</paragraph>
                             <ul_list>
                                 <list_item>
-                                    <paragraph>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</paragraph>
+                                    <paragraph>1 Lorem ipsum dolor sit amet, consectetur adipiscing elit.</paragraph>
                                 </list_item>
                                 <list_item>
-                                    <paragraph>Nulla a risus mauris.</paragraph>
+                                    <paragraph>2 Nulla a risus mauris.</paragraph>
                                 </list_item>
                                 <list_item>
-                                    <paragraph>Vestibulum ut felis ut augue maximus varius a sit amet ex.</paragraph>
+                                    <paragraph>3 Vestibulum ut felis ut augue maximus varius a sit amet ex.</paragraph>
                                 </list_item>
                             </ul_list>
                         </list_item>
                         <list_item>
-                            <paragraph>Vestibulum ut felis ut augue maximus varius a sit amet ex.</paragraph>
+                            <paragraph>6 Vestibulum ut felis ut augue maximus varius a sit amet ex.</paragraph>
                         </list_item>
                     </ul_list>
                 </list_item>
                 <list_item>
-                    <paragraph>Vestibulum ut felis ut augue maximus varius a sit amet ex.</paragraph>
+                    <paragraph>11 Vestibulum ut felis ut augue maximus varius a sit amet ex.</paragraph>
                 </list_item>
                 <list_item>
-                    <paragraph>Vestibulum elementum augue et ipsum aliquam, ut dignissim erat lacinia.Maecenas tempor blandit elit, vel mattis nulla.</paragraph>
+                    <paragraph>12 Vestibulum elementum augue et ipsum aliquam, ut dignissim erat lacinia.Maecenas tempor blandit elit, vel mattis nulla.</paragraph>
                     <ol_list>
                         <list_item>
-                            <paragraph>Phasellus lectus mauris, lacinia at eros quis, viverra vestibulum augue.</paragraph>
+                            <paragraph>7 Phasellus lectus mauris, lacinia at eros quis, viverra vestibulum augue.</paragraph>
                         </list_item>
                         <list_item>
                             <paragraph>
-                                Donec nec justo eu risus aliquet ullamcorper sit amet sodales tellus.
+                                8 Donec nec justo eu risus aliquet ullamcorper sit amet sodales tellus.
                             </paragraph>
                         </list_item>
                     </ol_list>
                 </list_item>
                 <list_item>
                     <paragraph>
-                        Donec nec justo eu risus aliquet ullamcorper sit amet sodales tellus.
+                        13 Donec nec justo eu risus aliquet ullamcorper sit amet sodales tellus.
                     </paragraph>
                 </list_item>
             </ul_list>

--- a/lib/changes/index.js
+++ b/lib/changes/index.js
@@ -3,8 +3,10 @@ import unwrapList from './unwrapList';
 import splitListItem from './splitListItem';
 import increaseItemDepth from './increaseItemDepth';
 import decreaseItemDepth from './decreaseItemDepth';
+import toggleList from './toggleList';
 
 export {
+    toggleList,
     wrapInList,
     unwrapList,
     splitListItem,

--- a/lib/changes/toggleList.js
+++ b/lib/changes/toggleList.js
@@ -1,0 +1,73 @@
+// @flow
+
+import { Document, Node } from 'slate';
+import Options from '../options';
+import { wrapInList } from '.';
+import isList from '../utils/isList';
+import isItem from '../utils/isItem';
+
+type MappedNode = {
+    depth: number,
+    node: Node
+};
+
+function filterListDescendants(options: Options, node: Node) {
+    return isList(options, node) || isItem(options, node);
+}
+
+function mapListDescendants(document: Document) {
+    return (node: Node) => ({
+        depth: document.getDepth(node.key),
+        node
+    });
+}
+
+function sortListDescendants(a: MappedNode, b: MappedNode): number {
+    if (a.depth !== b.depth) {
+        return b.depth - a.depth;
+    }
+
+    if (a.node.type === b.node.type) {
+        return 0;
+    }
+
+    if (a.node.type === 'list_item') {
+        return -1;
+    }
+
+    return 1;
+}
+
+function unwrapMappedNodes(change: Change, mappedNode: MappedNode) {
+    return change.unwrapBlockByKey(mappedNode.node.key, undefined, {
+        normalize: false
+    });
+}
+
+/**
+ * Toggle list on the selected range.
+ */
+function toggleList(options: Options, change: Change) {
+    const { document, selection } = change.value;
+
+    const startBlock = document.getClosestBlock(selection.start.key);
+    const endBlock = document.getClosestBlock(selection.end.key);
+    const commonAncestor = document.getCommonAncestor(
+        startBlock.key,
+        endBlock.key
+    );
+
+    if (!isList(options, commonAncestor)) {
+        return wrapInList(options, change);
+    }
+
+    const listsAndItems = commonAncestor
+        .filterDescendants(node => filterListDescendants(options, node))
+        .map(mapListDescendants(document))
+        .sort(sortListDescendants);
+
+    const newChange = listsAndItems.reduce(unwrapMappedNodes, change);
+    return newChange.unwrapBlockByKey(commonAncestor.key);
+}
+
+export default toggleList;

--- a/lib/core.js
+++ b/lib/core.js
@@ -2,6 +2,7 @@
 import Options, { type OptionsFormat } from './options';
 import { schema, normalizeNode } from './validation';
 import {
+    toggleList,
     wrapInList,
     unwrapList,
     splitListItem,
@@ -52,7 +53,8 @@ function core(
             increaseItemDepth: bindAndScopeChange(opts, increaseItemDepth),
             splitListItem: bindAndScopeChange(opts, splitListItem),
             unwrapList: bindAndScopeChange(opts, unwrapList),
-            wrapInList: wrapInList.bind(null, opts)
+            wrapInList: wrapInList.bind(null, opts),
+            toggleList: toggleList.bind(null, opts)
         }
     };
 }

--- a/lib/utils/isItem.js
+++ b/lib/utils/isItem.js
@@ -1,0 +1,13 @@
+// @flow
+import { type Node } from 'slate';
+
+import type Options from '../options';
+
+/**
+ * True if the node is a list item
+ */
+function isItem(opts: Options, node: Node): boolean {
+    return opts.typeItem.includes(node.type);
+}
+
+export default isItem;


### PR DESCRIPTION
This PR introduces `toggleList` function that removes the whole list hierarchy around a selection. If the selection is not in a list, it will create one. 