### PR TITLE
fix: propagate new list options to wrapInList in toggleList

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -77,8 +77,13 @@ const Example = () => {
                     Unwrap from list
                 </button>
 
+                <button
+                    onClick={() => Transforms.toggleList(editor, 'ol_list')}
+                >
+                    Toggle ordered list
+                </button>
                 <button onClick={() => Transforms.toggleList(editor)}>
-                    Toggle list
+                    Toggle unordered list
                 </button>
             </div>
         );

--- a/lib/commands/toggleList.js
+++ b/lib/commands/toggleList.js
@@ -46,7 +46,10 @@ const unwrapAllLists = (options: Options) => (
 /**
  * Toggle list on the selected range.
  */
-export const toggleList = (options: Options) => (editor: Editor): void => {
+export const toggleList = (options: Options) => (
+    editor: Editor,
+    ...newListOptions
+): void => {
     const range = editor.selection;
     const [startElement, startElementPath] = Editor.parent(
         editor,
@@ -64,7 +67,7 @@ export const toggleList = (options: Options) => (editor: Editor): void => {
         if (getItemsAtRange(options)(editor).length > 0) {
             unwrapList(options)(editor);
         } else {
-            wrapInList(options)(editor);
+            wrapInList(options)(editor, ...newListOptions);
         }
         return;
     }
@@ -85,7 +88,7 @@ export const toggleList = (options: Options) => (editor: Editor): void => {
 
     // There are no items or lists in selection => wrap them
     if (ancestorDescendantItems.length === 0) {
-        wrapInList(options)(editor);
+        wrapInList(options)(editor, ...newListOptions);
         return;
     }
 


### PR DESCRIPTION
When calling toggleList, you couldn't specify the options for the new list to be created (specifically, type and data). This is fixed now. 