### PR TITLE
fix: use correct chaining for new normalization

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,15 +41,10 @@ const KEY_TAB = 'Tab';
 const KEY_BACKSPACE = 'Backspace';
 
 const applyNormalization = (options: Options, editor: Editor): void => {
-    const defaultNormalization = editor.normalizeNode;
-
-    editor.normalizeNode = entry => {
-        childOfListIsAlwaysItem(options, entry, editor);
-        itemChildrenAreAlwaysElements(options, entry, editor);
-        itemsWithoutParentListAreUnwrapped(options, entry, editor);
-        joinAdjacentLists(options, entry, editor);
-        defaultNormalization(entry);
-    };
+    childOfListIsAlwaysItem(options, editor);
+    itemChildrenAreAlwaysElements(options, editor);
+    itemsWithoutParentListAreUnwrapped(options, editor);
+    joinAdjacentLists(options, editor);
 };
 
 /**

--- a/lib/normalizers/childOfListIsAlwaysItem.js
+++ b/lib/normalizers/childOfListIsAlwaysItem.js
@@ -9,33 +9,45 @@ import { type Options } from '..';
  */
 export function childOfListIsAlwaysItem(
     options: Options,
-    [node, nodePath]: NodeEntry,
     editor: Editor
 ): void {
-    let parentNodePath;
+    const { normalizeNode } = editor;
 
-    if (isItem(options)(node)) {
-        // we don't care for those that are items already
-        return;
-    }
+    editor.normalizeNode = (entry: NodeEntry): void => {
+        const [node, nodePath] = entry;
+        let parentNodePath;
 
-    try {
-        parentNodePath = Path.parent(nodePath);
-    } catch (e) {
-        // has no parent (ie. [0] node)
-        return;
-    }
+        if (isItem(options)(node)) {
+            // we don't care for those that are items already
+            normalizeNode(entry);
 
-    const parentNode = Node.get(editor, parentNodePath);
+            return;
+        }
 
-    if (isList(options)(parentNode)) {
-        const wrapperItem = {
-            type: options.typeItem,
-            children: [],
-        };
+        try {
+            parentNodePath = Path.parent(nodePath);
+        } catch (e) {
+            // has no parent (ie. [0] node)
+            normalizeNode(entry);
 
-        Transforms.wrapNodes(editor, wrapperItem, {
-            at: nodePath,
-        });
-    }
+            return;
+        }
+
+        const parentNode = Node.get(editor, parentNodePath);
+
+        if (isList(options)(parentNode)) {
+            const wrapperItem = {
+                type: options.typeItem,
+                children: [],
+            };
+
+            Transforms.wrapNodes(editor, wrapperItem, {
+                at: nodePath,
+            });
+
+            return;
+        }
+
+        normalizeNode(entry);
+    };
 }

--- a/lib/normalizers/itemChildrenAreAlwaysElements.js
+++ b/lib/normalizers/itemChildrenAreAlwaysElements.js
@@ -9,29 +9,38 @@ import type { Options } from '..';
  */
 export function itemChildrenAreAlwaysElements(
     options: Options,
-    nodeEntry: NodeEntry,
     editor: Editor
 ): void {
-    const [node, nodePath] = nodeEntry;
-    let parentNodePath;
+    const { normalizeNode } = editor;
 
-    try {
-        parentNodePath = Path.parent(nodePath);
-    } catch (e) {
-        // has no parent (ie. editor)
-        return;
-    }
+    editor.normalizeNode = (entry: NodeEntry): void => {
+        const [node, nodePath] = entry;
+        let parentNodePath;
 
-    const parentNode = Node.get(editor, parentNodePath);
+        try {
+            parentNodePath = Path.parent(nodePath);
+        } catch (e) {
+            // has no parent (ie. editor)
+            normalizeNode(entry);
 
-    if (!Element.isElement(node) && isItem(options)(parentNode)) {
-        const wrapperItem = {
-            type: options.typeDefault,
-            children: [],
-        };
+            return;
+        }
 
-        Transforms.wrapNodes(editor, wrapperItem, {
-            at: nodePath,
-        });
-    }
+        const parentNode = Node.get(editor, parentNodePath);
+
+        if (!Element.isElement(node) && isItem(options)(parentNode)) {
+            const wrapperItem = {
+                type: options.typeDefault,
+                children: [],
+            };
+
+            Transforms.wrapNodes(editor, wrapperItem, {
+                at: nodePath,
+            });
+
+            return;
+        }
+
+        normalizeNode(entry);
+    };
 }

--- a/lib/normalizers/itemsWithoutParentListAreUnwrapped.js
+++ b/lib/normalizers/itemsWithoutParentListAreUnwrapped.js
@@ -9,30 +9,41 @@ import type { Options } from '..';
  */
 export function itemsWithoutParentListAreUnwrapped(
     options: Options,
-    nodeEntry: NodeEntry,
     editor: Editor
 ): void {
-    const [node, nodePath] = nodeEntry;
-    let parentNodePath;
+    const { normalizeNode } = editor;
 
-    if (!isItem(options)(node)) {
-        return;
-    }
+    editor.normalizeNode = (entry: NodeEntry): void => {
+        const [node, nodePath] = entry;
+        let parentNodePath;
 
-    try {
-        parentNodePath = Path.parent(nodePath);
-    } catch (e) {
-        // has no parent (ie. [0] node)
-        return;
-    }
+        if (!isItem(options)(node)) {
+            normalizeNode(entry);
 
-    const parentNode = parentNodePath && Node.get(editor, parentNodePath);
+            return;
+        }
 
-    // either no parent or not a list parent
-    // in both cases, we unwrap list item
-    if (!parentNode || !isList(options)(parentNode)) {
-        Transforms.unwrapNodes(editor, {
-            at: nodePath,
-        });
-    }
+        try {
+            parentNodePath = Path.parent(nodePath);
+        } catch (e) {
+            // has no parent (ie. [0] node)
+            normalizeNode(entry);
+
+            return;
+        }
+
+        const parentNode = parentNodePath && Node.get(editor, parentNodePath);
+
+        // either no parent or not a list parent
+        // in both cases, we unwrap list item
+        if (!parentNode || !isList(options)(parentNode)) {
+            Transforms.unwrapNodes(editor, {
+                at: nodePath,
+            });
+
+            return;
+        }
+
+        normalizeNode(entry);
+    };
 }

--- a/lib/normalizers/joinAdjacentLists.js
+++ b/lib/normalizers/joinAdjacentLists.js
@@ -7,46 +7,54 @@ import type { Options } from '..';
 /**
  * A rule that joins adjacent lists of the same type
  */
-export function joinAdjacentLists(
-    options: Options,
-    nodeEntry: NodeEntry,
-    editor: Editor
-): void {
-    const [node, nodePath] = nodeEntry;
+export function joinAdjacentLists(options: Options, editor: Editor): void {
+    const { normalizeNode } = editor;
 
-    if (Element.isElement(node) && isList(options)(node)) {
-        let previousSiblingNodePath;
-        try {
-            previousSiblingNodePath = Path.previous(nodePath);
-        } catch (e) {
-            // the node doesn't have a previous sibling (ie. first)
-            return;
+    editor.normalizeNode = (entry: NodeEntry): void => {
+        const [node, nodePath] = entry;
+
+        if (Element.isElement(node) && isList(options)(node)) {
+            let previousSiblingNodePath;
+            try {
+                previousSiblingNodePath = Path.previous(nodePath);
+            } catch (e) {
+                // the node doesn't have a previous sibling (ie. first)
+                normalizeNode(entry);
+
+                return;
+            }
+
+            const previousSiblingNode = Node.get(
+                editor,
+                previousSiblingNodePath
+            );
+
+            if (
+                isList(options)(previousSiblingNode) &&
+                options.canMerge(node, previousSiblingNode)
+            ) {
+                const targetNodeLastChildIndex =
+                    previousSiblingNode.children.length - 1;
+
+                Editor.withoutNormalizing(editor, () => {
+                    const targetNodePath = [
+                        ...previousSiblingNodePath,
+                        // as the new last child of previous sibling list
+                        targetNodeLastChildIndex + 1,
+                    ];
+
+                    Transforms.insertNodes(editor, node.children, {
+                        at: targetNodePath,
+                    });
+
+                    Transforms.removeNodes(editor, {
+                        at: nodePath,
+                    });
+                });
+                return;
+            }
         }
 
-        const previousSiblingNode = Node.get(editor, previousSiblingNodePath);
-
-        if (
-            isList(options)(previousSiblingNode) &&
-            options.canMerge(node, previousSiblingNode)
-        ) {
-            const targetNodeLastChildIndex =
-                previousSiblingNode.children.length - 1;
-
-            Editor.withoutNormalizing(editor, () => {
-                const targetNodePath = [
-                    ...previousSiblingNodePath,
-                    // as the new last child of previous sibling list
-                    targetNodeLastChildIndex + 1,
-                ];
-
-                Transforms.insertNodes(editor, node.children, {
-                    at: targetNodePath,
-                });
-
-                Transforms.removeNodes(editor, {
-                    at: nodePath,
-                });
-            });
-        }
-    }
+        normalizeNode(entry);
+    };
 }


### PR DESCRIPTION
The previous implementation was not able to eject early after executing
   transforms, as all normalizations were run sequentially and ignored outputs
   of previous normalizations.