### PR TITLE
fix: rewrite of list item normalizer

### DIFF
--- a/lib/normalizers/itemChildrenAreAlwaysElements.js
+++ b/lib/normalizers/itemChildrenAreAlwaysElements.js
@@ -1,8 +1,47 @@
 // @flow
-import { Editor, NodeEntry, Node, Transforms, Path, Element } from 'slate';
+import { Editor, NodeEntry, Node, Transforms, Element } from 'slate';
 
 import { isItem } from '../utils';
 import type { Options } from '..';
+
+const createWrapperNode = (wrapperType: string): Node => ({
+    type: wrapperType,
+    children: [],
+});
+
+/**
+ * Generates new children by carrying over elements and grouping all
+ * non element nodes under a new wrapper node
+ */
+const getNewChildren = (
+    children: Array<Node>,
+    wrapperType: string
+): Array<Node> => {
+    const newChildren = [];
+    let needsNewWrapper = true;
+
+    children.forEach(child => {
+        if (Element.isElement(child)) {
+            newChildren.push(child);
+            needsNewWrapper = true;
+
+            return;
+        }
+
+        let currentGroup: Node = newChildren[newChildren.length - 1];
+        const shouldCreateNewGroup = !currentGroup || needsNewWrapper;
+
+        if (shouldCreateNewGroup) {
+            currentGroup = createWrapperNode(wrapperType);
+            newChildren.push(currentGroup);
+            needsNewWrapper = false;
+        }
+
+        currentGroup.children.push(child);
+    });
+
+    return newChildren;
+};
 
 /**
  * A rule that wraps children of lists with list item
@@ -15,27 +54,27 @@ export function itemChildrenAreAlwaysElements(
 
     editor.normalizeNode = (entry: NodeEntry): void => {
         const [node, nodePath] = entry;
-        let parentNodePath;
 
-        try {
-            parentNodePath = Path.parent(nodePath);
-        } catch (e) {
-            // has no parent (ie. editor)
+        if (!isItem(options)(node) || node.children.length === 0) {
             normalizeNode(entry);
 
             return;
         }
 
-        const parentNode = Node.get(editor, parentNodePath);
+        const hasTexts = node.children.some(child => !Element.isElement(child));
+        if (hasTexts) {
+            const newChildren = getNewChildren(
+                node.children,
+                options.typeDefault
+            );
 
-        if (!Element.isElement(node) && isItem(options)(parentNode)) {
-            const wrapperItem = {
-                type: options.typeDefault,
-                children: [],
-            };
-
-            Transforms.wrapNodes(editor, wrapperItem, {
-                at: nodePath,
+            Editor.withoutNormalizing(editor, () => {
+                Transforms.removeNodes(editor, { at: nodePath });
+                const newNode = {
+                    ...node,
+                    children: newChildren,
+                };
+                Transforms.insertNodes(editor, newNode, { at: nodePath });
             });
 
             return;

--- a/lib/normalizers/itemChildrenAreAlwaysElements.test.js
+++ b/lib/normalizers/itemChildrenAreAlwaysElements.test.js
@@ -149,6 +149,72 @@ const valueNestedList = {
     ],
 };
 
+const valueSingleItem = {
+    input: [
+        {
+            type: 'ul_list',
+            children: [
+                {
+                    type: 'list_item',
+                    children: [
+                        { text: 'first ', bold: true },
+                        { text: 'second', italic: true },
+                        {
+                            type: 'paragraph',
+                            children: [{ text: 'Another paragraph' }],
+                        },
+                        { text: 'third ', underline: true },
+                        {
+                            type: 'paragraph',
+                            children: [{ text: 'Another paragraph' }],
+                        },
+                        { text: 'fourth', italic: true },
+                        { text: 'fifth', whatever: true },
+                    ],
+                },
+            ],
+        },
+    ],
+    output: [
+        {
+            type: 'ul_list',
+            children: [
+                {
+                    type: 'list_item',
+                    children: [
+                        {
+                            type: 'paragraph',
+                            children: [
+                                { text: 'first ', bold: true },
+                                { text: 'second', italic: true },
+                            ],
+                        },
+                        {
+                            type: 'paragraph',
+                            children: [{ text: 'Another paragraph' }],
+                        },
+                        {
+                            type: 'paragraph',
+                            children: [{ text: 'third ', underline: true }],
+                        },
+                        {
+                            type: 'paragraph',
+                            children: [{ text: 'Another paragraph' }],
+                        },
+                        {
+                            type: 'paragraph',
+                            children: [
+                                { text: 'fourth', italic: true },
+                                { text: 'fifth', whatever: true },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
 const [withEditList] = EditListPlugin();
 let editor;
 
@@ -182,5 +248,11 @@ describe('itemChildrenAreAlwaysElements', () => {
         });
 
         expect(editor.children).toEqual(valueNestedList.output);
+    });
+
+    it('it works with single list item with marks', () => {
+        Transforms.insertNodes(editor, valueSingleItem.input);
+
+        expect(editor.children).toEqual(valueSingleItem.output);
     });
 });


### PR DESCRIPTION
Instead of checking in child of list whether it's an element, we now
check that list has all children as elements.
This prevents unintended wrapping of multiple text nodes (as would be
the case for different marks on the same line) in same number of
paragraphs. Original caused a bug, where single list item with
multiple marks was spread onto multiple lines, one per mark.