### PR TITLE
HB-469 Single item list separates inlines on new line

### DIFF
--- a/lib/normalizers/itemChildrenAreAlwaysElements.js
+++ b/lib/normalizers/itemChildrenAreAlwaysElements.js
@@ -14,6 +14,7 @@ const createWrapperNode = (wrapperType: string): Node => ({
  * non element nodes under a new wrapper node
  */
 const getNewChildren = (
+    editor: Editor,
     children: Array<Node>,
     wrapperType: string
 ): Array<Node> => {
@@ -21,7 +22,7 @@ const getNewChildren = (
     let needsNewWrapper = true;
 
     children.forEach(child => {
-        if (Element.isElement(child)) {
+        if (Element.isElement(child) && !editor.isInline(child)) {
             newChildren.push(child);
             needsNewWrapper = true;
 
@@ -64,6 +65,7 @@ export function itemChildrenAreAlwaysElements(
         const hasTexts = node.children.some(child => !Element.isElement(child));
         if (hasTexts) {
             const newChildren = getNewChildren(
+                editor,
                 node.children,
                 options.typeDefault
             );

--- a/lib/normalizers/itemChildrenAreAlwaysElements.test.js
+++ b/lib/normalizers/itemChildrenAreAlwaysElements.test.js
@@ -170,6 +170,7 @@ const valueSingleItem = {
                         },
                         { text: 'fourth', italic: true },
                         { text: 'fifth', whatever: true },
+                        { type: 'link', children: [{ text: 'link text' }] },
                     ],
                 },
             ],
@@ -206,6 +207,11 @@ const valueSingleItem = {
                             children: [
                                 { text: 'fourth', italic: true },
                                 { text: 'fifth', whatever: true },
+                                {
+                                    type: 'link',
+                                    children: [{ text: 'link text' }],
+                                },
+                                { text: '' },
                             ],
                         },
                     ],
@@ -221,6 +227,7 @@ let editor;
 describe('itemChildrenAreAlwaysElements', () => {
     beforeEach(() => {
         editor = withEditList(withReact(createEditor()));
+        editor.isInline = element => element.type === 'link';
     });
 
     it('it wraps item child with default element if not element', () => {


### PR DESCRIPTION
This just adds the correct fix for children of list item that
should be grouped together under a new wrapped element.