### PR TITLE
fix: more flexible getTopmostItemsAtRange

### DIFF
--- a/lib/utils/getTopmostItemsAtRange.js
+++ b/lib/utils/getTopmostItemsAtRange.js
@@ -1,7 +1,10 @@
 // @flow
-import { Range, NodeEntry, Editor, Path, Node } from 'slate';
+import { Range, NodeEntry, Editor, Node, Path } from 'slate';
 import { type Options } from '..';
 import { getCurrentItem, isItem, isList } from '.';
+
+const takeOnlyDirectChildren = ancestorPath => ([, listItemPath]) =>
+    listItemPath.length === ancestorPath.length + 1;
 
 /**
  * Return the array of items at the given range. The returned items are
@@ -33,25 +36,28 @@ export const getTopmostItemsAtRange = (options: Options) => (
         return item ? [item] : [];
     }
 
-    const ancestorPath = Path.common(startElementPath, endElementPath);
-    const ancestor = Node.get(editor, ancestorPath);
+    let ancestorPath = Path.common(startElementPath, endElementPath);
+    let ancestor = Node.get(editor, ancestorPath);
 
-    if (isList(options)(ancestor)) {
-        return [
-            ...Editor.nodes(editor, {
-                at: range,
-                match: isItem(options),
-            }),
-            // We want only the children of the ancestor
-            // aka the topmost possible list items in the selection
-        ].filter(
-            ([, listItemPath]) =>
-                listItemPath.length === ancestorPath.length + 1
-        );
-    } else if (isItem(options)(ancestor)) {
-        // The ancestor is the highest list item that covers the range
-        return [[ancestor, ancestorPath]];
+    while (ancestorPath.length !== 0) {
+        if (isList(options)(ancestor)) {
+            return [
+                ...Editor.nodes(editor, {
+                    at: range,
+                    match: isItem(options),
+                }),
+                // We want only the children of the ancestor
+                // aka the topmost possible list items in the selection
+            ].filter(takeOnlyDirectChildren(ancestorPath));
+        } else if (isItem(options)(ancestor)) {
+            // The ancestor is the highest list item that covers the range
+            return [[ancestor, ancestorPath]];
+        }
+
+        ancestorPath = ancestorPath.slice(0, -1);
+        ancestor = Node.get(editor, ancestorPath);
     }
+
     // No list of items can cover the range
     return [];
 };

--- a/lib/utils/getTopmostItemsAtRange.test.js
+++ b/lib/utils/getTopmostItemsAtRange.test.js
@@ -121,9 +121,29 @@ const value = [
     },
 ];
 
+const valueTraverseToEditor = [
+    {
+        type: 'something',
+        children: [
+            {
+                type: 'something',
+                children: [
+                    {
+                        type: 'something',
+                        children: [{ text: 'foo' }],
+                    },
+                    {
+                        type: 'something',
+                        children: [{ text: 'bar' }],
+                    },
+                ],
+            },
+        ],
+    },
+];
+
 const pathFirstNestedListFirstLeafNode = [0, 2, 0, 0, 0, 0];
 const pathFirstNestedListSecondLeafNode = [0, 2, 0, 1, 0, 0];
-const pathFirstNestedListThirdLeafNode = [0, 2, 0, 2, 0, 0];
 const pathSecondNestedListLeafNode = [0, 2, 1, 0, 0, 0];
 const pathParagraphLeafButLastNode = [1, 0];
 const pathParagraphLeafLastNode = [2, 0];
@@ -218,6 +238,20 @@ describe('getTopmostItemsAtRange', () => {
             ];
 
             expect(listItemsArray).toEqual(expected);
+        });
+    });
+
+    describe('when there are no lists', () => {
+        it('when we check all ancestors up to the editor', () => {
+            editor.children = valueTraverseToEditor;
+            Transforms.select(editor, {
+                anchor: { path: [0, 0, 0, 0], offset: 0 },
+                focus: { path: [0, 0, 1, 0], offset: 0 },
+            });
+
+            const listItemsArray = Editor.getTopmostItemsAtRange(editor);
+
+            expect(listItemsArray).toEqual([]);
         });
     });
 });


### PR DESCRIPTION
Function now traverses ancestor chain up to an Editor to look for
list or list_item. This still satisfies the function contract, while
accepting more diverse selections spanning different levels of nodes.