### PR TITLE
HB-495: fix: unwrap when multiple lists are in selection

### DIFF
--- a/lib/commands/toggleList.test.js
+++ b/lib/commands/toggleList.test.js
@@ -343,7 +343,7 @@ const valueNestedListSelection = {
     ],
 };
 
-const valueNestedListSelectionParentNotList = {
+const valueNestedListSelectionParentEditor = {
     input: [
         {
             type: 'paragraph',
@@ -379,27 +379,12 @@ const valueNestedListSelectionParentNotList = {
             children: [{ text: 'Item 1' }],
         },
         {
-            type: 'ul_list',
-            children: [
-                {
-                    type: 'list_item',
-                    children: [
-                        {
-                            type: 'paragraph',
-                            children: [{ text: 'Item 2' }],
-                        },
-                    ],
-                },
-                {
-                    type: 'list_item',
-                    children: [
-                        {
-                            type: 'paragraph',
-                            children: [{ text: 'Item 3' }],
-                        },
-                    ],
-                },
-            ],
+            type: 'paragraph',
+            children: [{ text: 'Item 2' }],
+        },
+        {
+            type: 'paragraph',
+            children: [{ text: 'Item 3' }],
         },
     ],
 };
@@ -516,26 +501,25 @@ describe('toggleList', () => {
 
             expect(editor.children).toEqual(valueNestedListSelection.output);
         });
-        describe('when selection ancestor not a list', () => {
-            it('does nothing', () => {
-                editor.children = valueNestedListSelectionParentNotList.input;
 
-                Transforms.select(editor, {
-                    anchor: {
-                        path: [0, 0],
-                        offset: 0,
-                    },
-                    focus: {
-                        path: [1, 0, 0, 0],
-                        offset: 0,
-                    },
-                });
-                Transforms.toggleList(editor);
+        it('when selection ancestor is editor unwraps correct lists', () => {
+            editor.children = valueNestedListSelectionParentEditor.input;
 
-                expect(editor.children).toEqual(
-                    valueNestedListSelectionParentNotList.output
-                );
+            Transforms.select(editor, {
+                anchor: {
+                    path: [0, 0],
+                    offset: 0,
+                },
+                focus: {
+                    path: [1, 0, 0, 0],
+                    offset: 0,
+                },
             });
+            Transforms.toggleList(editor);
+
+            expect(editor.children).toEqual(
+                valueNestedListSelectionParentEditor.output
+            );
         });
     });
 });

--- a/lib/utils/getTopmostItemsAtRange.js
+++ b/lib/utils/getTopmostItemsAtRange.js
@@ -39,6 +39,28 @@ export const getTopmostItemsAtRange = (options: Options) => (
     let ancestorPath = Path.common(startElementPath, endElementPath);
     let ancestor = Node.get(editor, ancestorPath);
 
+    if (Editor.isEditor(ancestor)) {
+        const topMostLists = [
+            ...Editor.nodes(editor, {
+                at: range,
+                match: isList(options),
+                mode: 'highest',
+            }),
+        ];
+
+        return topMostLists.reduce((items, [, listPath]) => {
+            const topMostListItems = [
+                ...Editor.nodes(editor, {
+                    at: listPath,
+                    match: isItem(options),
+                    mode: 'highest',
+                }),
+            ];
+
+            return items.concat(topMostListItems);
+        }, []);
+    }
+
     while (ancestorPath.length !== 0) {
         if (isList(options)(ancestor)) {
             return [

--- a/lib/utils/getTopmostItemsAtRange.test.js
+++ b/lib/utils/getTopmostItemsAtRange.test.js
@@ -119,6 +119,42 @@ const value = [
         type: 'paragraph',
         children: [{ text: 'Item' }],
     },
+    {
+        type: 'ul_list',
+        children: [
+            {
+                type: 'list_item',
+                children: [
+                    {
+                        type: 'paragraph',
+                        children: [
+                            {
+                                text: 'Item',
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        type: 'ul_list',
+        children: [
+            {
+                type: 'list_item',
+                children: [
+                    {
+                        type: 'paragraph',
+                        children: [
+                            {
+                                text: 'Item',
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
 ];
 
 const valueTraverseToEditor = [
@@ -147,6 +183,8 @@ const pathFirstNestedListSecondLeafNode = [0, 2, 0, 1, 0, 0];
 const pathSecondNestedListLeafNode = [0, 2, 1, 0, 0, 0];
 const pathParagraphLeafButLastNode = [1, 0];
 const pathParagraphLeafLastNode = [2, 0];
+const pathSecondTopmostList = [3, 0, 0, 0];
+const pathLastTopmostList = [4, 0, 0, 0];
 const pathOneItemFirstParagraph = [0, 0, 0, 0];
 const pathOneItemSecondParagraph = [0, 0, 1, 0];
 
@@ -235,6 +273,43 @@ describe('getTopmostItemsAtRange', () => {
             const expected = [
                 buildExpectedNodeEntry(editor, [0, 1]),
                 buildExpectedNodeEntry(editor, [0, 2]),
+            ];
+
+            expect(listItemsArray).toEqual(expected);
+        });
+
+        it('on multiple lists in selection returns topmost items of every list', () => {
+            Transforms.select(editor, {
+                anchor: { path: [0, 0, 0, 0], offset: 0 },
+                focus: { path: pathSecondTopmostList, offset: 0 },
+            });
+
+            const listItemsArray = Editor.getTopmostItemsAtRange(editor);
+
+            const expected = [
+                buildExpectedNodeEntry(editor, [0, 0]),
+                buildExpectedNodeEntry(editor, [0, 1]),
+                buildExpectedNodeEntry(editor, [0, 2]),
+                buildExpectedNodeEntry(editor, [3, 0]),
+            ];
+
+            expect(listItemsArray).toEqual(expected);
+        });
+
+        it('when everything is selected returns all topmost items', () => {
+            Transforms.select(editor, {
+                anchor: { path: [0, 0, 0, 0], offset: 0 },
+                focus: { path: pathLastTopmostList, offset: 0 },
+            });
+
+            const listItemsArray = Editor.getTopmostItemsAtRange(editor);
+
+            const expected = [
+                buildExpectedNodeEntry(editor, [0, 0]),
+                buildExpectedNodeEntry(editor, [0, 1]),
+                buildExpectedNodeEntry(editor, [0, 2]),
+                buildExpectedNodeEntry(editor, [3, 0]),
+                buildExpectedNodeEntry(editor, [4, 0]),
             ];
 
             expect(listItemsArray).toEqual(expected);


### PR DESCRIPTION
There was an issue where multiple lists in selection wouldn't get unwrapped (because we specifically ignored the case when ancestor node is editor itself). This PR fixes that.